### PR TITLE
ci: stop testing against NodeJS v10, v14, v16, v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
     strategy:
       matrix:
         node_version:
-          - 12
-          - 14
-          - 16
+          - 20
+          - 22
+          - 24
     steps:
       - uses: actions/checkout@v3
       - name: "Use Node.js ${{ matrix.node_version }}"

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
         "@pika/plugin-build-web"
       ]
     ]
+  },
+  "engines": {
+    "node": ">= 20"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v10, v14, v16, v18